### PR TITLE
feat: include source locations in console logs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import 'source-map-support/register';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';

--- a/src/shared/trace/tracing.console-logger.ts
+++ b/src/shared/trace/tracing.console-logger.ts
@@ -1,46 +1,45 @@
 import { ConsoleLogger, Injectable } from '@nestjs/common';
+import path from 'node:path';
 import { ensureSeed, getCtx, getDepth, getExecId } from './context';
 
 @Injectable()
 export class TracingConsoleLogger extends ConsoleLogger {
-  private fmt(level: string, message: any, ctx?: string) {
+  private fmt(level: string, message: unknown, ctx?: string) {
     ensureSeed();
     const id = getExecId() ?? '–';
     const d = getDepth();
     const tag = ctx ?? getCtx() ?? '';
     const prefix = `[${id}] [d=${d}]${tag ? ` [${tag}]` : ''}`;
-
-    // 기본 NestJS 색상/포맷은 부모(ConsoleLogger)가 처리 → 여기서는 prefix만 추가
-    return `${prefix} ${message}`;
+    const loc = this.getLocation(3);
+    // 기본 NestJS 색상/포맷은 부모(ConsoleLogger)가 처리 → 여기서는 prefix와 위치만 추가
+    return `${prefix} ${String(message)} (${loc})`;
   }
 
-  log(message: any, context?: string) {
+  log(message: unknown, context?: string) {
     super.log(this.fmt('LOG', message, context), context);
   }
-  error(message: any, stack?: string, context?: string) {
-    const msg = stack ? `${message}\n${stack}` : message;
+  error(message: unknown, stack?: string, context?: string) {
+    const base = String(message);
+    const msg = stack ? `${base}\n${stack}` : base;
     super.error(this.fmt('ERROR', msg, context), stack, context);
   }
-  warn(message: any, context?: string) {
+  warn(message: unknown, context?: string) {
     super.warn(this.fmt('WARN', message, context), context);
   }
-  debug(message: any, context?: string) {
+  debug(message: unknown, context?: string) {
     super.debug(this.fmt('DEBUG', message, context), context);
   }
-  verbose(message: any, context?: string) {
+  verbose(message: unknown, context?: string) {
     super.verbose(this.fmt('VERBOSE', message, context), context);
   }
 
-  getLocation(d: number): string {
+  getLocation(depth = 2): string {
     const stack = new Error().stack?.split('\n') ?? [];
-    console.log(stack);
-    const line = stack?.[d] ?? ''; // depth=2면 호출 지점 기준
+    const line = stack[depth] ?? '';
     const match = line.match(/\(([^)]+):(\d+):\d+\)$/);
-
     if (!match) return 'unknown';
-
     const [, fullPath, lineNum] = match;
-    const file = fullPath.split('/').pop() ?? fullPath;
-    return `${file}:${lineNum}`;
+    const rel = path.relative(process.cwd(), fullPath);
+    return `${rel}:${lineNum}`;
   }
 }


### PR DESCRIPTION
## Summary
- add stack trace parsing to console logger
- log relative TypeScript source locations along with messages

## Testing
- `pnpm test` (fails: No tests found)
- `pnpm lint` (fails: 65 errors)

------
https://chatgpt.com/codex/tasks/task_e_68ad91d0ecd8832f98aa84bd6d38cd88